### PR TITLE
Add CONFIG_WROVER_KIT_V1 flag to control LCD backlight polarity

### DIFF
--- a/components/nofrendo-esp32/spi_lcd.c
+++ b/components/nofrendo-esp32/spi_lcd.c
@@ -50,8 +50,14 @@
 #define LCD_SEL_DATA()  GPIO.out_w1ts = (1 << PIN_NUM_DC) // High to send data
 #define LCD_RST_SET()   GPIO.out_w1ts = (1 << PIN_NUM_RST) 
 #define LCD_RST_CLR()   GPIO.out_w1tc = (1 << PIN_NUM_RST)
+
+#ifdef CONFIG_WROVER_KIT_V1
 #define LCD_BKG_ON()    GPIO.out_w1ts = (1 << PIN_NUM_BCKL) // Backlight ON
-#define LCD_BKG_OFF()   GPIO.out_w1tc = (1 << PIN_NUM_BCKL) //Backlight OFF
+#define LCD_BKG_OFF()   GPIO.out_w1tc = (1 << PIN_NUM_BCKL) // Backlight OFF
+#else
+#define LCD_BKG_ON()    GPIO.out_w1tc = (1 << PIN_NUM_BCKL) // Backlight ON
+#define LCD_BKG_OFF()   GPIO.out_w1ts = (1 << PIN_NUM_BCKL) // Backlight OFF
+#endif
 
 
 #define SPI_NUM  0x3


### PR DESCRIPTION
Default to later versions of the board (currently just V2) which reverse
the polarity.

I couldn't figure out a good way to add a config option through Kconfig for this without modifying esp-idf itself. Open to suggestions / modifications.